### PR TITLE
Updated translation

### DIFF
--- a/Locale/pt_PT/translations.php
+++ b/Locale/pt_PT/translations.php
@@ -30,4 +30,6 @@ return array(
     'Burndown chart for "%s"' => 'Gráfico de Burndown para "%s"',
     'Budget overview' => 'Visão geral do orçamento',
     'Type' => 'Tipo',
+    'Add budget section for projects and expense reports based on user hourly rates' => 'Adicionar secção de orçamento para projectos e relatórios de despesas com base em taxas horárias de utilizadores',
+    'There is not enough data to show something.' => 'Não há nada para mostrar',
 );


### PR DESCRIPTION
Missing "There is not enough data to show something." and "'Add budget section for projects and expense reports based on user hourly rates" on translations files
